### PR TITLE
Wrap code in README.md in code blocks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.DS_Store
+.Rhistory
+.cache/

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ lecture directory.
 
 Once you have completed this step run the commands:
 
-```
+```r
 slidify("index.Rmd")
 browseURL("index.html")
 ```

--- a/README.md
+++ b/README.md
@@ -11,18 +11,20 @@ To download the folder with the slides for all lectures, click on the button to 
 You will need to install [R](http://cran.rstudio.com/), [Rstudio](http://www.rstudio.com/ide/download/) and Slidify. To install Slidify, open Rstudio and run the commands:
 
 
+```r
 install.packages("devtools")
-
 install_github("slidify","ramnathv")
-
 install_github("slidifyLibraries","ramnathv")
+```
 
 
 ## Setting your working directory
 
 Next, you need to set your working directory to the lecture you would like to compile. 
 
+```r
 setwd(file.choose())
+```
 
 and select the directory of the lecture you would like to compile. This will set your working directory to the 
 lecture directory. 
@@ -32,7 +34,9 @@ lecture directory.
 
 Once you have completed this step run the commands:
 
+```
 slidify("index.Rmd")
 browseURL("index.html")
+```
 
 This should compile the slides and open the resulting webpage on your computer. 


### PR DESCRIPTION
Just a simple cosmetic fix, wrapping up code blocks in README.md so that they are syntax highlighted by github.
