### PR TITLE
representingDataR: slide 16: second subset example: wrong instruction and output

### DIFF
--- a/005representingDataR/index.Rmd
+++ b/005representingDataR/index.Rmd
@@ -176,7 +176,7 @@ myDataFrame$firstNames
 ## Logical subsetting
 ```{r}
 myDataFrame[myDataFrame$firstNames=="jeff",]
-myDataFrame[heights < 190,]
+myDataFrame[myDataFrame$heights < 190,]
 ```
 
 ---


### PR DESCRIPTION
Corrects the second R subset instruction on slide 16 and its erroneous output (the observation heights=192.3).  The correct output is automatically generated by recompiling the slides.
